### PR TITLE
Downcase information_schema column names, supporting MySQL

### DIFF
--- a/lib/hypershield.rb
+++ b/lib/hypershield.rb
@@ -119,6 +119,7 @@ module Hypershield
 
       Hash[
         select_all(query)
+          .map { |c| c.transform_keys(&:downcase) }
           .group_by { |c| c["table_name"] }
           .map { |t, cs| [t, cs.sort_by { |c| c["ordinal_position"].to_i }.map { |c| c["column_name"] }] }
       ]


### PR DESCRIPTION
When trying to use Hypershield with a MySQL 8 database I found the `tables` method only returning nil values. Turns out the `information_schemal.columns` column names were coming in as all caps. This PR remedies that.

Thanks for a great tool.