### PR TITLE
Sleep for 0.5s for each 20 CREATE VIEW on large databases. Create test DB for tests.

### DIFF
--- a/test/many_tables_test.rb
+++ b/test/many_tables_test.rb
@@ -1,0 +1,25 @@
+require_relative "test_helper"
+
+class ManyTablesTest < Minitest::Test
+  TABLES = (0..Hypershield::LARGE_NUMBER_OF_VIEWS+1)
+
+  def setup
+    TABLES.each do |table|
+      ActiveRecord::Migration.create_table "users_#{table}".to_sym, force: true do |t|
+        t.string :name
+        t.string :encrypted_email
+      end
+    end
+  end
+
+  def test_it_works
+    assert Hypershield.refresh
+  end
+
+  def teardown
+    TABLES.each do |table|
+      ActiveRecord::Base.connection.execute "DROP VIEW IF EXISTS hypershield.users_#{table}"
+      ActiveRecord::Migration.drop_table "users_#{table}".to_sym, force: true
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,8 +12,8 @@ ActiveRecord::Base.logger = logger
 # create test database if not exists
 adapter = ENV["ADAPTER"] || "postgresql"
 database = adapter == "postgresql" ? "postgres" : "mysql"
-user = adapter == "mysql2" ? "root" : nil
-password = adapter == "mysql2" ? "root" : nil
+user = ENV["DB_USER"]
+password = ENV["DB_PASSWORD"]
 
 ActiveRecord::Base.establish_connection adapter: adapter, database: database, username: user, password: password
 ActiveRecord::Base.connection.execute "DROP DATABASE IF EXISTS hypershield_test"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,9 +9,18 @@ logger = ActiveSupport::Logger.new(STDOUT)
 # for debugging
 ActiveRecord::Base.logger = logger
 
-# migrations
+# create test database if not exists
 adapter = ENV["ADAPTER"] || "postgresql"
-ActiveRecord::Base.establish_connection adapter: adapter, database: "hypershield_test"
+database = adapter == "postgresql" ? "postgres" : "mysql"
+user = adapter == "mysql2" ? "root" : nil
+password = adapter == "mysql2" ? "root" : nil
+
+ActiveRecord::Base.establish_connection adapter: adapter, database: database, username: user, password: password
+ActiveRecord::Base.connection.execute "DROP DATABASE IF EXISTS hypershield_test"
+ActiveRecord::Base.connection.execute "CREATE DATABASE hypershield_test"
+
+# migrations
+ActiveRecord::Base.establish_connection adapter: adapter, database: "hypershield_test", username: user, password: password
 
 ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.users")
 ActiveRecord::Base.connection.execute("DROP SCHEMA IF EXISTS hypershield")


### PR DESCRIPTION
### Problem
During migrations on large databases with 700+ tables, we noticed that recreating large number of views caused IOPS (input/output operations per second) spikes. After some research, we learned that Postgres flushes these views to disk and asks all backends (connections) to refresh them immediately, causing a thundering herd effect.

### Solution
On databases with 200 tables or more: 1) remove transactions from view creation (immediate flush), 2) sleep for 0.5 seconds between each 20 views created.

### Other stuff
Added creating/dropping test databases (so we can run tests with just `bundle exec rake`).