### PR TITLE
Execute All Refresh View Statements Separately

### DIFF
--- a/lib/hypershield.rb
+++ b/lib/hypershield.rb
@@ -57,12 +57,8 @@ module Hypershield
 
         if statements.any?
           connection.transaction do
-            if mysql?
-              statements.each do |statement|
-                execute(statement)
-              end
-            else
-              execute(statements.join(";\n"))
+            statements.each do |statement|
+              execute(statement)
             end
           end
         end


### PR DESCRIPTION
Hi @ankane!

My team over at [dev.to](https://github.com/thepracticaldev/dev.to) is trying to implement this gem to shield our views in [Blazer](https://github.com/ankane/blazer). I got it working great in development, however, when we went to deploy to production we kept getting timeouts while trying to update the schema. 

After checking out the source code I noticed for databases that are not MySQL (we run Postgres) all the statements are executed at once. Is there a specific reason you choose to do it that way? If not, might I suggest running them one by one to avoid those timeouts for all databases? 

Let me know what you think!

Thanks! 