### PR TITLE
Add remove_reference to migration methods

### DIFF
--- a/lib/hypershield/migration.rb
+++ b/lib/hypershield/migration.rb
@@ -3,7 +3,8 @@ module Hypershield
     def method_missing(method, *args)
       if [
         :change_column, :drop_table, :remove_column, :remove_columns,
-        :remove_timestamps, :rename_column, :rename_table
+        :remove_timestamps, :rename_column, :rename_table,
+        :remove_reference
       ].include?(method)
         Hypershield.drop_view(args[0])
       end


### PR DESCRIPTION
Hey @ankane!

When trying to run rails migrations our team has noticed that the method `remove_reference` is not included in the keyword list for dropping views. Just wondering if it's possible to add this in?

Thanks!
