### PR TITLE
Enhance db:prepare too

### DIFF
--- a/lib/tasks/hypershield.rake
+++ b/lib/tasks/hypershield.rake
@@ -23,3 +23,7 @@ end
 Rake::Task["db:rollback"].enhance do
   Rake::Task["hypershield:refresh"].invoke if Hypershield.enabled
 end
+
+Rake::Task["db:prepare"].enhance do
+  Rake::Task["hypershield:refresh"].invoke if Hypershield.enabled
+end


### PR DESCRIPTION
supposedly it was added in rails 6 (https://blog.saeloun.com/2019/04/11/rails-6-rails-db-prepare/), so should be okay not to check if the rake task is defined